### PR TITLE
Use `sync+restart` and add `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: build up open-browser watch touch-index.js touch-gatsby-config.js touch-package.json down
+
+build:
+	docker compose build
+
+up:
+	docker compose up -d
+
+open-browser:
+	open http://localhost:8000
+
+watch:
+	docker compose watch
+
+touch-index.js:
+	touch site/src/pages/index.js
+
+touch-gatsby-config.js:
+	touch site/gatsby-config.js
+
+touch-package.json:
+	touch site/package.json
+
+down:
+	docker compose down
+

--- a/README.md
+++ b/README.md
@@ -12,20 +12,33 @@ A working example to test `docker compose watch`.
 
 ```zsh
 # Build:
+make build
+# or
 docker compose build
 
 # Start containers:
+make up
+# or
 docker compose up -d
 
 # Open the page with browser:
+make open-browser
+# or
 open http://localhost:8000
 
 # Watch:
+make watch
+# or
 docker compose watch
 
 # Try changing files in `site/src/` or `site/gatsby-config.js` to see the watch works.
+make touch-index.js  # => sync
+make touch-gatsby-config.js  # => sync+restart
+make touch-package.json  # => rebuild
 
 # Stop containers:
+make down
+# or 
 docker compose down
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ docker compose down
 Docker version 24.0.6, build ed223bc
 
 ❯ docker compose version
-Docker Compose version v2.22.0-desktop.2
+Docker Compose version v2.23.0-desktop.1
 ```
 
 `docker version`:
@@ -52,7 +52,7 @@ Client:
  OS/Arch:           darwin/arm64
  Context:           desktop-linux
 
-Server: Docker Desktop 4.24.0 (122432)
+Server: Docker Desktop 4.25.0 (126437)
  Engine:
   Version:          24.0.6
   API version:      1.43 (minimum version 1.12)

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,10 +9,13 @@ services:
         - action: sync
           path: ./site/src/
           target: /app/src
-        - action: sync
+        # `sync+restart` was introduced in v2.23.0.
+        # See: https://github.com/docker/compose/releases/tag/v2.23.0
+        - action: sync+restart
           path: ./site/gatsby-config.js
           target: /app/gatsby-config.js
         - action: rebuild
           path: ./site/package.json
         - action: rebuild
           path: ./site/package-lock.json
+


### PR DESCRIPTION
Use the new `sync+restart` action.

Commits:

- Use action `sync+restart` that was introduced in `v2.23.0`
- Add `Makefile` for easier use

See:

- https://github.com/docker/compose/releases/tag/v2.23.0
- https://docs.docker.com/desktop/release-notes/#4250